### PR TITLE
`\LaTeX` Implementation: replace deprecated style function (Typst 0.12)

### DIFF
--- a/public/impl-in-typst.html
+++ b/public/impl-in-typst.html
@@ -67,24 +67,24 @@ $
   <li>LaTeX: <code>\LaTeX</code></li>
   <li>Implementation in Typst <sup><a href="#ref-latex">[2]</a></sup>
   <pre><code>
-#let TeX = style(styles => {
+#let TeX = context {
   set text(font: "New Computer Modern")
-  let e = measure("E", styles)
+  let e = measure("E")
   let T = "T"
   let E = text(1em, baseline: e.height * 0.31, "E")
   let X = "X"
   box(T + h(-0.15em) + E + h(-0.125em) + X)
-})
+}
 
-#let LaTeX = style(styles => {
+#let LaTeX = context {
   set text(font: "New Computer Modern")
   let a-size = 0.66em
-  let l = measure("L", styles)
-  let a = measure(text(a-size, "A"), styles)
+  let l = measure("L")
+  let a = measure(text(a-size, "A"))
   let L = "L"
   let A = box(scale(x: 105%, text(a-size, baseline: a.height - l.height, "A")))
   box(L + h(-a.width * 0.67) + A + h(-a.width * 0.25) + TeX)
-})
+}
 </code></pre>
   </li>
   <li>


### PR DESCRIPTION
See https://typst.app/docs/changelog/0.12.0/#deprecations